### PR TITLE
Multi-LED for STM32F3-Discovery

### DIFF
--- a/hw/bsp/stm32f3discovery/include/bsp/bsp.h
+++ b/hw/bsp/stm32f3discovery/include/bsp/bsp.h
@@ -32,7 +32,14 @@ extern "C" {
 #define bssnz_t         sec_bss_nz_core
 
 /* LED pins */
-#define LED_BLINK_PIN   (72)
+#define LED_BLINK_PIN_1   (72)
+#define LED_BLINK_PIN_2   (73)
+#define LED_BLINK_PIN_3   (74)
+#define LED_BLINK_PIN_4   (75)
+#define LED_BLINK_PIN_5   (76)
+#define LED_BLINK_PIN_6   (77)
+#define LED_BLINK_PIN_7   (78)
+#define LED_BLINK_PIN_8   (79)
 
 /* UART ports */
 #define UART_CNT        1


### PR DESCRIPTION
I added pin definitions for the other LEDs on the STM32F3-Discovery board to be able to enhance the Blinky Demo Code.
